### PR TITLE
Fixed #16 getRemoteIndex does not seem to resolve …

### DIFF
--- a/src/utils/getRemoteIndex.js
+++ b/src/utils/getRemoteIndex.js
@@ -10,21 +10,18 @@ module.exports = async function getRemoteIndex(index) {
 }
 
 function query(index) {
-    return new Promise(function(resolve, reject) { 
-        index.browse("", {}, function browseDone(err, content, hits) {
+    return new Promise(function(resolve, reject) {
+        hits = []; 
+        index.browse("", {}, function browseDone(err, content) {
             if (err) reject(err);
-
-            if (!Array.isArray(hits)) {
-                hits = []
-            }
-
+            
             content.hits.forEach(function(hit) {
                 hit.objectID = String(hit.objectID)
                 hits.push(hit)
             })
-        
+
             if (content.cursor) {
-                resolve(index.browseFrom(content.cursor, browseDone, hits))
+                index.browseFrom(content.cursor, browseDone);
             } else {
                 resolve(hits)
             }


### PR DESCRIPTION
…on > 1000 entries indices.

Added a fix for this (which works for my productive deployment with ~ 2300 records). 

Hope you can merge it and republish package, as it does not seem very active at the moment. Would be shame to have to continue the patched version.

BTW, great tool which saved me a lot of time.