### PR TITLE
Import 'debug' to resolve reference error

### DIFF
--- a/src/utils/idsFromIndex.js
+++ b/src/utils/idsFromIndex.js
@@ -1,3 +1,5 @@
+var debug = require('debug')('atomic-algolia:idsFromIndex')
+
 module.exports = function idsFromIndex(index) {
   return index.reduce(function(hits, hit) {
       if (hit !== null && hit !== undefined) {


### PR DESCRIPTION
## What I observed

I got a `ReferenceError` when I entered abnormal block in `idsFromIndex()`

```
    ReferenceError: debug is not defined

       9 |         return hits.concat(id)
      10 |     } else {
    > 11 |       debug(`Missing object id, ignored hit: %o`, hit);
         |       ^
      12 |
      13 |       return hits;
      14 |     }

      at debug (src/utils/idsFromIndex.js:11:7)
          at Array.reduce (<anonymous>)
      at reduce (src/utils/idsFromIndex.js:6:10)
      at idsFromIndex (src/utils/calculateOperations.js:10:23)
      at calculateOperations (src/update.js:36:34)
```

## What I did in this PR

Resolve the error by importing package 'debug'